### PR TITLE
tweak(client): don't override voice proximity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ exports["x-instance"]:getPlayerInstance(source)
 
 ## TODO
 - [x] Find a way to prevent instanced players from hearing each other(possibly through pma-voice export).
-- [ ] Find a way to disable pvp between instanced players that are not in a same instance.
-- [ ] Find a way to disable gun shots to be heard by instanced players.
+- [x] Find a way to disable pvp between instanced players that are not in a same instance.
+- [x] Find a way to disable gun shots to be heard by instanced players.
 - [x] Optimize it more than its current state.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,8 +4,9 @@ lua54       "yes"
 game        "gta5"
 
 name        "x-instance"
-version     "0.0.0"
-description "Project-X Instance"
+version     "0.5.0"
+repository  "https://github.com/XProject/x-radiolist"
+description "Project-X Instance: Player instancing system like Rockstar"
 
 shared_scripts {
     "shared/*.lua",

--- a/server/main.lua
+++ b/server/main.lua
@@ -222,8 +222,8 @@ if Config.Debug then
         print(success, message)
     end, false)
 
-    --[[
     -- populate instances table for testing the execution time of iterating over it in client
+    --[[
     math.randomseed()
     function randomString(length)
         local res = ""


### PR DESCRIPTION
I must have not checked the funtionality of voice proxmity check when I moved from modifying players vibislity & their collision to using the actual consealing natives on them. 

Credit to theLindat for make it known conseal natives make the entities' coords -180 by z attribute locally.