### PR TITLE
feat(server/client): update player conceal state on playerEnteredScope

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -140,6 +140,24 @@ AddStateBagChangeHandler(Shared.State.vehicleInstance, nil, function(bagName, _,
     local conceal = value and not (value.instance == currentInstance and value.host == currentHost) or false
     NetworkConcealEntity(entityHandler, conceal)
 end)
+
+RegisterNetEvent(Shared.Event.playerEnteredScope, function(playerServerId)
+    if GetInvokingResource() then return end
+    if playerServerId ~= PLAYER_SERVER_ID then
+        local player = GetPlayerFromServerId(playerServerId)
+
+        if player ~= -1 and NetworkIsPlayerActive(player) then
+            if instancedPlayers[playerServerId] then
+                local instanceName, instanceHost = instancedPlayers[playerServerId].instance, instancedPlayers[playerServerId].host
+                local conceal = ((instanceName == currentInstance and instanceHost == currentHost) and false) or true
+                NetworkConcealPlayer(player, conceal, conceal)
+            elseif not instancedPlayers[playerServerId] and NetworkIsPlayerConcealed(player) then -- this elseif should not technically be needed because everytime a player joins another player's scope, since a new player is being created, the players is not concealed anyway...(OneSync baby)
+                NetworkConcealPlayer(player, false, false)
+            end
+        end
+    end
+end)
+
 local function onResourceStop(resource)
     if resource ~= Shared.currentResourceName then return end
     for playerServerId in pairs(instancedPlayers) do

--- a/server/main.lua
+++ b/server/main.lua
@@ -360,7 +360,9 @@ exports("getVehicleInstance", getVehicleInstance)
 
 AddEventHandler("playerEnteredScope", function(data)
     local playerEntering, player = tonumber(data["player"]), tonumber(data["for"])
+    print(("%s is entering %s's scope"):format(playerEntering, player))
     if not playerEntering or not player then return end
+    Wait(1000) -- wait because sometimes once server thinks a player is entered another player's scope, the client is not aware of that yet!
     TriggerClientEvent(Shared.Event.playerEnteredScope, playerEntering, player)
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -358,6 +358,12 @@ local function getVehicleInstance(vehicleNetId)
 end
 exports("getVehicleInstance", getVehicleInstance)
 
+AddEventHandler("playerEnteredScope", function(data)
+    local playerEntering, player = tonumber(data["player"]), tonumber(data["for"])
+    if not playerEntering or not player then return end
+    TriggerClientEvent(Shared.Event.playerEnteredScope, playerEntering, player)
+end)
+
 local function onResourceStop(resource)
     if resource ~= Shared.currentResourceName then return end
     GlobalState:set(Shared.State.globalInstancedPlayers, {}, true)

--- a/shared/shared.lua
+++ b/shared/shared.lua
@@ -14,6 +14,10 @@ Shared.State.playerInstance = ("%s_playerInstance"):format(Shared.currentResourc
 
 Shared.State.vehicleInstance = ("%s_vehicleInstance"):format(Shared.currentResourceName)
 
+Shared.Event = {}
+
+Shared.Event.playerEnteredScope = ("%s:playerEnteredScope"):format(Shared.currentResourceName)
+
 ---@alias playerSource number
 ---@alias instanceName string
 ---@alias hostSource playerSource


### PR DESCRIPTION
Because of OneSync Infinity, whenever a player enters another player's scope, a new player entity is created and the concealment state needs to be re-applied to ensure all players are properly concealed.